### PR TITLE
Don't add to a project board or trigger any workflows on creation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,3 @@ jobs:
       - uses: actions/checkout@master
       - name: Test
         run: make test
-      - name: Build Binary
-        run: make default
-      - name: Pulumi preview
-        uses: pulumi/actions@v3
-        with:
-          work-dir: pulumi
-          command: preview
-          stack-name: pulumi/github-issue-automation
-          comment-on-pr: true
-          diff: true

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,8 @@ deploy-dev: .build/new-release-handler.zip .build/internal-release-handler.zip p
 
 .PHONY: test
 test: lambda/new-release-handler/go.sum lambda/internal-release-handler/go.sum
-	cd lambda/new-release-handler && go test && cd ../internal-release-handler && go test
+	cd lambda/new-release-handler && go test ./...
+	cd lambda/internal-release-handler && go test ./...
 
 .PHONY: refresh
 refresh:

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ clean:
 	rm .build/*
 
 # Intended for local deployment only
-.PHONY: deploy
-deploy: .build/new-release-handler.zip .build/internal-release-handler.zip pulumi/*
+.PHONY: deploy-dev
+deploy-dev: .build/new-release-handler.zip .build/internal-release-handler.zip pulumi/*
 	cd pulumi && pulumi up -s dev
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-default: .build/new-release-handler.zip .build/internal-release-handler.zip
+default: build
+
+.PHONY: build
+build: .build/new-release-handler.zip .build/internal-release-handler.zip
 
 .build/internal-release-handler.zip: .build/internal-release-handler
 	cd .build && zip internal-release-handler.zip internal-release-handler

--- a/README.md
+++ b/README.md
@@ -38,5 +38,9 @@ Be sure to tear down the stack if you deploy locally for testing to avoid causin
 ## Testing changes for automatic upstream provider updates
 
 1. In the AWS console, find your development Lambda, send a test event (see .`sample-events/sample-event.json` for an example and edit the fields as necessary) via the `Test` tab.
-2. Observe the Pulumi provider action "Update upstream provider" being triggered. *Note*: this is a real Action and will result in an automatic update and merge if the Action passes.
-3. When done testing, tear down the pulumi dev stack: `cd pulumi && pulumi destroy pulumi/dev`.
+1. Observe the Pulumi provider action "Update upstream provider" being triggered. *Note*: this is a real Action and will result in an automatic update and merge if the Action passes.
+1. When done testing, tear down the pulumi dev stack: `cd pulumi && pulumi destroy pulumi/dev`.
+
+## Deployment
+
+Main is automatically deployed on Pulumi's corp account with Pulumi Deployments.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ See `doc/release-handler.yml` for an example of the triggering GHA workflow. A m
 
 1. Ensure that an environment variable `GITHUB_TOKEN` is set to a value that allows the creation of GitHub issues for all repositories in the `pulumi` GitHub org and can add issues to the Platform Integrations Board.
 1. Set your `AWS_PROFILE` environment variable to the pulumi-dev-sandbox account and log in.
-1. `make deploy`
+1. `make deploy-dev`
 
 Some resources in this stack have static names because they are referenced outside the stack by name, therefore the stack cannot be deployed in the same AWS account more than once. 
 Be sure to tear down the stack if you deploy locally for testing to avoid causing issues for teammates.


### PR DESCRIPTION
We used to track upgrades by adding them to the a GH project:
https://github.com/orgs/pulumi/projects/28#card-91004424. We don't do this anymore, so we
don't need to keep the code to add it.

We used to run an automated workflow: "update-upstream-provider.yml", on issue
creation. This workflow no longer exists. We run the modern equivalent by triggering on issue creation.

We can simplify this project by removing both of these pieces of automation.